### PR TITLE
Request for Metro Extracts for Porto, Portugal

### DIFF
--- a/cities.txt
+++ b/cities.txt
@@ -52,6 +52,7 @@ Europe	2992166	43.910	4.488	43.241	3.381	montpellier	Montpellier
 Europe	524901	56.200	36.870	55.285	38.430	moscow	Moscow
 Europe	2867714	48.523	10.799	47.717	12.178	munich	Munich
 Europe	2988507	49.178	1.851	48.531	2.911	paris	Paris
+Europe 	2735943	41.399	-8.795	-8.358	40.981	porto	Porto
 Europe	3067696	50.408	13.842	49.763	15.012	prague	Prague
 Europe	3169070	42.130	12.109	41.578	12.845	rome	Rome
 Europe	2747891	52.109	3.911	51.737	4.784	rotterdam	Rotterdam


### PR DESCRIPTION
Added Porto, Portugal, and its metropolitan area, to cities.txt.
