### PR TITLE
Correction to 'Europe' whitespace, in the entry of Porto, at cities.txt

### DIFF
--- a/cities.txt
+++ b/cities.txt
@@ -52,7 +52,7 @@ Europe	2992166	43.910	4.488	43.241	3.381	montpellier	Montpellier
 Europe	524901	56.200	36.870	55.285	38.430	moscow	Moscow
 Europe	2867714	48.523	10.799	47.717	12.178	munich	Munich
 Europe	2988507	49.178	1.851	48.531	2.911	paris	Paris
-Europe 	2735943	41.399	-8.795	40.981	-8.358	porto	Porto
+Europe	2735943	41.399	-8.795	40.981	-8.358	porto	Porto
 Europe	3067696	50.408	13.842	49.763	15.012	prague	Prague
 Europe	3169070	42.130	12.109	41.578	12.845	rome	Rome
 Europe	2747891	52.109	3.911	51.737	4.784	rotterdam	Rotterdam


### PR DESCRIPTION
The last extract at http://metro.teczno.com/ has duplicates for the continent Europe, with only one city entry on the second instance for Porto.

Went to check the source code and noticed that it was listed as 'Europe ', while already 'Europe' existed, so I corrected the whitespace for the entry of Porto, on the file cities.txt.

My mistake, sorry. Thanks for also previously fixing the lat/long of Porto, which weren't in the correct order on my last pull request.
